### PR TITLE
Added snapshot_arns parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This creates a redis cluster with some default values and creates a security gro
  * [`availability_zones`]: String: the list of AZs where you want your cluster to be deployed in (The number of azs must be <= num_cache_nodes)
  * [`snapshot_window`]: String: The daily time range (in UTC) during which ElastiCache will begin taking a daily snapshot of your cache cluster. The minimum maintenance window is a 60 minute period. Example: 05:00-09:00
  * [`snapshot_retention_limit`]: String: The number of days for which ElastiCache will retain automatic cache cluster snapshots before deleting them. For example, if you set SnapshotRetentionLimit to 5, then a snapshot that was taken today will be retained for 5 days before being deleted. If the value of SnapshotRetentionLimit is set to zero (0), backups are turned off. Please note that setting a snapshot_retention_limit is not supported on cache.t1.micro or cache.t2.* cache nodes
- * [`snapshot_arns`]: String(Optional): A single-element string list containing an Amazon Resource Name (ARN) of a Redis RDB snapshot file stored in Amazon S3. Example: arn:aws:s3:::my_bucket/snapshot1.rdb
+ * [`snapshot_arns`]: List(Optional): A single-element string list containing an Amazon Resource Name (ARN) of a Redis RDB snapshot file stored in Amazon S3. Example: arn:aws:s3:::my_bucket/snapshot1.rdb
 
 ### Output
 * [`redis_sg`]: String: The security group ID of the redis cluster.

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ This creates a redis cluster with some default values and creates a security gro
  * [`availability_zones`]: String: the list of AZs where you want your cluster to be deployed in (The number of azs must be <= num_cache_nodes)
  * [`snapshot_window`]: String: The daily time range (in UTC) during which ElastiCache will begin taking a daily snapshot of your cache cluster. The minimum maintenance window is a 60 minute period. Example: 05:00-09:00
  * [`snapshot_retention_limit`]: String: The number of days for which ElastiCache will retain automatic cache cluster snapshots before deleting them. For example, if you set SnapshotRetentionLimit to 5, then a snapshot that was taken today will be retained for 5 days before being deleted. If the value of SnapshotRetentionLimit is set to zero (0), backups are turned off. Please note that setting a snapshot_retention_limit is not supported on cache.t1.micro or cache.t2.* cache nodes
+ * [`snapshot_arns`]: String(Optional): A single-element string list containing an Amazon Resource Name (ARN) of a Redis RDB snapshot file stored in Amazon S3. Example: arn:aws:s3:::my_bucket/snapshot1.rdb
 
 ### Output
 * [`redis_sg`]: String: The security group ID of the redis cluster.

--- a/redis/main.tf
+++ b/redis/main.tf
@@ -13,6 +13,7 @@ resource "aws_elasticache_replication_group" "redis" {
   automatic_failover_enabled    = "${var.automatic_failover_enabled}"
   snapshot_window               = "${var.snapshot_window}"
   snapshot_retention_limit      = "${var.snapshot_retention_limit}"
+  snapshot_arns                 = "${var.snapshot_arns}"
 
   tags {
     Name        = "${var.project}-${var.environment}-${var.name}"

--- a/redis/variables.tf
+++ b/redis/variables.tf
@@ -65,3 +65,8 @@ variable "snapshot_retention_limit" {
   description = "The number of days for which ElastiCache will retain automatic cache cluster snapshots before deleting them. For example, if you set SnapshotRetentionLimit to 5, then a snapshot that was taken today will be retained for 5 days before being deleted. If the value of SnapshotRetentionLimit is set to zero (0), backups are turned off. Please note that setting a snapshot_retention_limit is not supported on cache.t1.micro or cache.t2.* cache nodes"
   default     = "0"
 }
+
+variable "snapshot_arns" {
+  description = "(Optional) A single-element string list containing an Amazon Resource Name (ARN) of a Redis RDB snapshot file stored in Amazon S3. Example: arn:aws:s3:::my_bucket/snapshot1.rdb"
+  default     = ""
+}

--- a/redis/variables.tf
+++ b/redis/variables.tf
@@ -68,5 +68,6 @@ variable "snapshot_retention_limit" {
 
 variable "snapshot_arns" {
   description = "(Optional) A single-element string list containing an Amazon Resource Name (ARN) of a Redis RDB snapshot file stored in Amazon S3. Example: arn:aws:s3:::my_bucket/snapshot1.rdb"
-  default     = ""
+  type        = "list"
+  default     = []
 }


### PR DESCRIPTION
This is needed to seed an .rdb backup file into a new redis cluster.