### PR TITLE
fixing unexisting output in redis module

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ This creates a redis cluster with some default values and creates a security gro
 
 ### Output
 * [`redis_sg`]: String: The security group ID of the redis cluster.
-* [`configuration_endpoint_address`]: String: The address of the endpoint for the primary node in the replication group. If Redis, only present when cluster mode is disabled.
 * [`primary_endpoint_address`]: String: The address of the replication group configuration endpoint when cluster mode is enabled.
 
 ### Example

--- a/redis/outputs.tf
+++ b/redis/outputs.tf
@@ -2,10 +2,6 @@ output "redis_sg" {
   value = "${aws_security_group.sg_redis.id}"
 }
 
-output "configuration_endpoint_address" {
-  value = "${aws_elasticache_replication_group.redis.configuration_endpoint_address}"
-}
-
 output "primary_endpoint_address" {
   value = "${aws_elasticache_replication_group.redis.primary_endpoint_address}"
 }


### PR DESCRIPTION
As per terraform documentation (https://www.terraform.io/docs/providers/aws/r/elasticache_replication_group.html#configuration_endpoint_address) `configuration_endpoint_address` is the address of the replication group configuration endpoint only when cluster mode is enabled. Currently the redis module does not support cluster mode. 

For those reasons I've removed that output