### PR TITLE
make Redis snapshots system more robust

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ This creates a redis cluster with some default values and creates a security gro
  * [`at_rest_encryption_enabled`]: Bool(Optional, true) Whether to enable encryption at rest
  * [`transit_encryption_enabled`]: Bool(Optional, true) Whether to enable encryption in transit
  * [`auth_token`]: String(Optional) The password used to access a password protected server. Can be specified only if `transit_encryption_enabled = true`
+ * [`notification_topic_arn`]: String(Optional) (Optional) ARN of an SNS topic to send ElastiCache notifications
 
 ### Output
 * [`redis_sg`]: String: The security group ID of the redis cluster.

--- a/redis-snapshot-replicator/monitoring.tf
+++ b/redis-snapshot-replicator/monitoring.tf
@@ -1,0 +1,100 @@
+resource "aws_cloudwatch_metric_alarm" "lambda_redis_snapshot_copy_errors" {
+  count               = var.enable ? 1 : 0
+  alarm_name          = "redis_snapshot_copy_lambda_${var.environment}_errors"
+  alarm_description   = "The errors on redis_snapshot_copy are higher than 1"
+  namespace           = "AWS/Lambda"
+  metric_name         = "Errors"
+  statistic           = "Sum"
+  comparison_operator = "GreaterThanThreshold"
+  threshold           = 1
+  evaluation_periods  = 1
+  period              = 21600 # 6 hours
+
+  alarm_actions = [var.sns_topic_arn]
+  ok_actions    = [var.sns_topic_arn]
+
+  dimensions = {
+    FunctionName = aws_lambda_function.redis_copy_snapshot[0].function_name
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "lambda_redis_snapshot_create_errors" {
+  count               = var.enable ? 1 : 0
+  alarm_name          = "redis_snapshot_create_invocation_${var.environment}_errors"
+  alarm_description   = "The errors on redis_snapshot_create are higher than 1"
+  namespace           = "AWS/Lambda"
+  metric_name         = "Errors"
+  statistic           = "Sum"
+  comparison_operator = "GreaterThanThreshold"
+  threshold           = 1
+  evaluation_periods  = 1
+  period              = 3600*${var.custom_snapshot_rate}
+
+  alarm_actions = [var.sns_topic_arn]
+  ok_actions    = [var.sns_topic_arn]
+
+  dimensions = {
+    FunctionName = aws_lambda_function.redis_create_snapshot[0].function_name
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "lambda_redis_snapshot_cleanup_errors" {
+  count               = var.enable ? 1 : 0
+  alarm_name          = "redis_snapshot_cleanup_lambda_${var.environment}_errors"
+  alarm_description   = "The errors on redis_snapshot_cleanup are higher than 1"
+  namespace           = "AWS/Lambda"
+  metric_name         = "Errors"
+  statistic           = "Sum"
+  comparison_operator = "GreaterThanThreshold"
+  threshold           = 1
+  evaluation_periods  = 1
+  period              = 86400 # 24 hours
+
+  alarm_actions = [var.sns_topic_arn]
+  ok_actions    = [var.sns_topic_arn]
+
+  dimensions = {
+    FunctionName = aws_lambda_function.redis_remove_snapshot[0].function_name
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "invoke_redis_snapshot_lambda" {
+  count               = var.enable ? 1 : 0
+  alarm_name          = "redis-snapshot-invocation-${var.environment}-failed-invocations"
+  alarm_description   = "Failed invocations for redis-snapshot-lambda"
+  namespace           = "AWS/Events"
+  metric_name         = "FailedInvocations"
+  statistic           = "Sum"
+  comparison_operator = "GreaterThanThreshold"
+  threshold           = 1
+  evaluation_periods  = 1
+  period              = 21600 # 6 hours
+
+  alarm_actions = [var.sns_topic_arn]
+  ok_actions    = [var.sns_topic_arn]
+
+  dimensions = {
+    RuleName = "invoke-redis-snapshot-lambda-${var.environment}"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "invoke_redis_cleanup_lambda" {
+  count               = var.enable ? 1 : 0
+  alarm_name          = "redis-cleanup-invocations-${var.environment}-failed-invocations"
+  alarm_description   = "Failed invocations for redis-cleanup-lambda"
+  namespace           = "AWS/Events"
+  metric_name         = "FailedInvocations"
+  statistic           = "Sum"
+  comparison_operator = "GreaterThanThreshold"
+  threshold           = 1
+  evaluation_periods  = 1
+  period              = 86400 # 24 hours
+
+  alarm_actions = [var.sns_topic_arn]
+  ok_actions    = [var.sns_topic_arn]
+
+  dimensions = {
+    RuleName = "invoke-redis-cleanup-lambda-${var.environment}"
+  }
+}
+

--- a/redis-snapshot-replicator/monitoring.tf
+++ b/redis-snapshot-replicator/monitoring.tf
@@ -1,3 +1,9 @@
+locals {
+  cw_alarm_custom_period = 3600 * var.custom_snapshot_rate
+  cw_alarm_daily_period  = 3600 * 24
+}
+
+
 resource "aws_cloudwatch_metric_alarm" "lambda_redis_snapshot_copy_errors" {
   count               = var.enable ? 1 : 0
   alarm_name          = "redis_snapshot_copy_lambda_${var.environment}_errors"
@@ -8,7 +14,7 @@ resource "aws_cloudwatch_metric_alarm" "lambda_redis_snapshot_copy_errors" {
   comparison_operator = "GreaterThanThreshold"
   threshold           = 1
   evaluation_periods  = 1
-  period              = 21600 # 6 hours
+  period              = local.cw_alarm_custom_period
 
   alarm_actions = [var.sns_topic_arn]
   ok_actions    = [var.sns_topic_arn]
@@ -28,8 +34,7 @@ resource "aws_cloudwatch_metric_alarm" "lambda_redis_snapshot_create_errors" {
   comparison_operator = "GreaterThanThreshold"
   threshold           = 1
   evaluation_periods  = 1
-  period              = 3600*${var.custom_snapshot_rate}
-
+  period              = local.cw_alarm_custom_period
   alarm_actions = [var.sns_topic_arn]
   ok_actions    = [var.sns_topic_arn]
 
@@ -48,7 +53,7 @@ resource "aws_cloudwatch_metric_alarm" "lambda_redis_snapshot_cleanup_errors" {
   comparison_operator = "GreaterThanThreshold"
   threshold           = 1
   evaluation_periods  = 1
-  period              = 86400 # 24 hours
+  period              = local.cw_alarm_daily_period
 
   alarm_actions = [var.sns_topic_arn]
   ok_actions    = [var.sns_topic_arn]
@@ -68,7 +73,7 @@ resource "aws_cloudwatch_metric_alarm" "invoke_redis_snapshot_lambda" {
   comparison_operator = "GreaterThanThreshold"
   threshold           = 1
   evaluation_periods  = 1
-  period              = 21600 # 6 hours
+  period              = local.cw_alarm_custom_period
 
   alarm_actions = [var.sns_topic_arn]
   ok_actions    = [var.sns_topic_arn]
@@ -88,7 +93,7 @@ resource "aws_cloudwatch_metric_alarm" "invoke_redis_cleanup_lambda" {
   comparison_operator = "GreaterThanThreshold"
   threshold           = 1
   evaluation_periods  = 1
-  period              = 86400 # 24 hours
+  period              = local.cw_alarm_daily_period
 
   alarm_actions = [var.sns_topic_arn]
   ok_actions    = [var.sns_topic_arn]

--- a/redis-snapshot-replicator/variables.tf
+++ b/redis-snapshot-replicator/variables.tf
@@ -27,6 +27,12 @@ variable "custom_snapshot_rate" {
   description = "Number of hours to take custom RDS snapshots every each"
 }
 
+variable "sns_topic_arn" {
+  type        = string
+  description = "ARN of SNS topic to use for monitoring of the snapshot creation, copy, and cleanup process"
+}
+
+
 variable "redis_sns_topic_arn" {
   type        = string
   description = "ARN of SNS topic the ElastiCache cluster sends notification to"

--- a/redis-snapshot-replicator/variables.tf
+++ b/redis-snapshot-replicator/variables.tf
@@ -18,6 +18,22 @@ variable "enable" {
 }
 
 variable "environment" {
-  type    = string
+  type = string
 }
 
+variable "custom_snapshot_rate" {
+  type        = number
+  default     = 6
+  description = "Number of hours to take custom RDS snapshots every each"
+}
+
+variable "redis_sns_topic_arn" {
+  type        = string
+  description = "ARN of SNS topic the ElastiCache cluster sends notification to"
+}
+
+
+variable "backup_retention_days" {
+  type    = number
+  default = 30
+}

--- a/redis/main.tf
+++ b/redis/main.tf
@@ -17,6 +17,7 @@ resource "aws_elasticache_replication_group" "redis" {
   at_rest_encryption_enabled    = var.at_rest_encryption_enabled
   transit_encryption_enabled    = var.transit_encryption_enabled
   auth_token                    = var.auth_token
+  notification_topic_arn        = var.notification_topic_arn 
 
   tags = {
     Name        = "${var.project}-${var.environment}-${var.name}"

--- a/redis/variables.tf
+++ b/redis/variables.tf
@@ -102,3 +102,9 @@ variable "auth_token" {
   type        = string
 }
 
+
+variable "notification_topic_arn" {
+  description = "(Optional) ARN of an SNS topic to send ElastiCache notifications"
+  default     = null
+  type        = string
+}


### PR DESCRIPTION
- fix snapshot cleanup lambda function pagination and make it delete snapshots based on retention period
- add ifecycle policy to the s3 backup to cleanup backups older than the retention period
- add monitoring for the lambda functions
- switch copy snapshot lambda to be triggered from sns topic with a filtered policy for created snapshots 
- add optional configuration in the elasticache cluster to allow setting notifications topic 

Related issue: https://github.com/skyscrapers/q1_6/issues/135